### PR TITLE
fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
 configurations.all {
     if (file("../FF4StatsLib").exists()) {
         resolutionStrategy.dependencySubstitution {
-            substitute project(":FF4StatsLib") with module("com.github.sg4e:FF4StatsLib:master-SNAPSHOT")
+            substitute module("com.github.sg4e:FF4StatsLib:master-SNAPSHOT") with project(":FF4StatsLib")
         }
     }
 }

--- a/src/main/java/sg4e/maikatracker/MaikaTracker.form
+++ b/src/main/java/sg4e/maikatracker/MaikaTracker.form
@@ -93,9 +93,9 @@
                       <EmptySpace max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="0" attributes="0">
                           <Component id="scriptLabel" min="-2" max="-2" attributes="0"/>
-                          <Component id="jScrollPane3" min="-2" pref="220" max="-2" attributes="0"/>
+                          <Component id="jScrollPane3" min="-2" pref="110" max="-2" attributes="0"/>
                       </Group>
-                      <EmptySpace pref="125" max="32767" attributes="0"/>
+                      <EmptySpace pref="235" max="32767" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>

--- a/src/main/java/sg4e/maikatracker/MaikaTracker.java
+++ b/src/main/java/sg4e/maikatracker/MaikaTracker.java
@@ -897,8 +897,8 @@ public class MaikaTracker extends javax.swing.JFrame {
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(bossPaneLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(scriptLabel)
-                    .addComponent(jScrollPane3, javax.swing.GroupLayout.PREFERRED_SIZE, 220, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addContainerGap(125, Short.MAX_VALUE))
+                    .addComponent(jScrollPane3, javax.swing.GroupLayout.PREFERRED_SIZE, 110, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addContainerGap(235, Short.MAX_VALUE))
         );
 
         mainTabbedPane.addTab("Bosses", bossPane);
@@ -1300,9 +1300,11 @@ public class MaikaTracker extends javax.swing.JFrame {
             model.setValueAt(NUMBER_FORMAT.format(enemy.getMaxSpeed()), i, 4);
             model.setValueAt(NUMBER_FORMAT.format(enemy.getSpellPower()), i, 5);
             enemy.getScriptValues().forEach(scr -> {
-                if(scripts.length() > 0)
-                    scripts.append("\n");
-                scripts.append(scr);
+                if(scr.length() > 0) {
+                    if(scripts.length() > 0)
+                        scripts.append("\n");
+                    scripts.append(scr);
+                }
             });
         }
         enemyScriptTextArea.setText(scripts.toString());

--- a/src/main/java/sg4e/maikatracker/MaikaTracker.java
+++ b/src/main/java/sg4e/maikatracker/MaikaTracker.java
@@ -1299,13 +1299,19 @@ public class MaikaTracker extends javax.swing.JFrame {
             model.setValueAt(NUMBER_FORMAT.format(enemy.getMinSpeed()), i, 3);
             model.setValueAt(NUMBER_FORMAT.format(enemy.getMaxSpeed()), i, 4);
             model.setValueAt(NUMBER_FORMAT.format(enemy.getSpellPower()), i, 5);
+                        
+            StringBuilder enemyScript = new StringBuilder();
             enemy.getScriptValues().forEach(scr -> {
                 if(scr.length() > 0) {
-                    if(scripts.length() > 0)
-                        scripts.append("\n");
-                    scripts.append(scr);
+                    if(enemyScript.length() > 0)
+                        enemyScript.append("\n");
+                    enemyScript.append(scr);
                 }
             });
+            
+            if(scripts.length() > 0 && enemyScript.length() > 0)
+                scripts.append("\n-----------\n");
+            scripts.append(enemyScript);
         }
         enemyScriptTextArea.setText(scripts.toString());
     }


### PR DESCRIPTION
* build.gradle substitution line was wrong.  Fixed, so that it actually does use the local version if it exists.
* Fixed script text area to be smaller, by not having empty lines be appended to the script heading.
* Scripts seperated by ------ if required, to make them less confusing, in particular, the elements spot scripts.