### PR TITLE
More flagset stuff

### DIFF
--- a/src/main/java/sg4e/maikatracker/KeyItemPanel.java
+++ b/src/main/java/sg4e/maikatracker/KeyItemPanel.java
@@ -62,13 +62,7 @@ public class KeyItemPanel extends JPanel {
                     MaikaTracker tracker = MaikaTracker.getTrackerFromChild(KeyItemPanel.this);
                     if(!isKnown() || !tracker.isResetOnly()) {
                         locationMenu = ((MaikaTracker)SwingUtilities.getWindowAncestor(KeyItemPanel.this))
-                                .getAvailableLocationsMenu(loc -> {
-                                    if(isKnown())
-                                        reset();
-                                    location = loc;
-                                    locationLabel.setText(loc.getAbbreviatedLocation());
-                                    locationLabel.setToolTipText(loc.getLocation());
-                                });
+                                .getAvailableLocationsMenu(loc -> setLocation(loc));
                         locationMenu.add(new JSeparator(), 0);
                         JMenuItem custom = new JMenuItem("Chest location");
                         custom.addActionListener((ae) -> {
@@ -118,6 +112,14 @@ public class KeyItemPanel extends JPanel {
         locationLabel = new JLabel(UNKNOWN_LOCATION, JLabel.CENTER);
         locationLabel.setAlignmentX(JLabel.CENTER_ALIGNMENT);        
         add(locationLabel, BorderLayout.CENTER);
+    }
+    
+    public void setLocation(KeyItemLocation loc) {
+        if(isKnown())
+            reset();
+        location = loc;
+        locationLabel.setText(loc.getAbbreviatedLocation());
+        locationLabel.setToolTipText(loc.getLocation());
     }
     
     public void setTextColor(Color color) {
@@ -171,6 +173,75 @@ public class KeyItemPanel extends JPanel {
         location = null;
         if(resetIcon)
             ((StativeLabel)itemImage).reset();
+        
+        if(tracker.flagset == null) {
+            resetting = false;
+            return;
+        }
+        
+        if (tracker.flagset != null && !tracker.flagset.contains("K")) {
+            switch(metadata) {
+                case ADAMANT:
+                    setLocation(KeyItemLocation.RAT_TAIL);
+                    break;
+                case BARON_KEY:
+                    setLocation(KeyItemLocation.BARON_INN);
+                    break;
+                case CRYSTAL:
+                    setLocation(tracker.flagset.contains("V1") ? KeyItemLocation.KOKKOL : KeyItemLocation.ZEROMUS);
+                    break;
+                case DARKNESS:
+                    setLocation(KeyItemLocation.SEALED_CAVE);
+                    break;
+                case EARTH:
+                    setLocation(KeyItemLocation.DARK_ELF);
+                    break;
+                case HOOK:
+                    setLocation(KeyItemLocation.LOW_BABIL);
+                    break;
+                case LEGEND:
+                    setLocation(KeyItemLocation.ORDEALS);
+                    break;
+                case LUCA_KEY:
+                    setLocation(KeyItemLocation.DWARF_CASTLE);
+                    break;
+                case MAGMA_KEY:
+                    setLocation(KeyItemLocation.ZOT);
+                    break;
+                case PACKAGE:
+                    setLocation(KeyItemLocation.START);
+                    break;
+                case PAN:
+                    setLocation(KeyItemLocation.SHEILA_PANLESS);
+                    break;
+                case PASS:
+                    if(tracker.flagset.contains("Pk"))
+                        setLocation(KeyItemLocation.BARON_CASTLE);
+                    break;
+                case PINK_TAIL:                    
+                    break;
+                case RAT_TAIL:
+                    setLocation(KeyItemLocation.SUMMONED_MONSTERS_CHEST);
+                    break;
+                case SAND_RUBY:
+                    setLocation(KeyItemLocation.ANTLION);
+                    break;
+                case SPOON:
+                    setLocation(KeyItemLocation.SHEILA_PAN);
+                    break;
+                case TOWER_KEY:
+                    setLocation(KeyItemLocation.TOP_BABIL);
+                    break;
+                case TWIN_HARP:
+                    if(tracker.flagset == null)
+                        break;
+                    setLocation(tracker.flagset.contains("Nk") ? KeyItemLocation.MIST : KeyItemLocation.TOROIA);
+                    break;
+            }
+        }
+        else if(tracker.flagset.contains("V1") && metadata.equals(KeyItemMetadata.CRYSTAL))
+            setLocation(KeyItemLocation.KOKKOL);
+        
         
         resetting = false;
     }

--- a/src/main/java/sg4e/maikatracker/MaikaTracker.form
+++ b/src/main/java/sg4e/maikatracker/MaikaTracker.form
@@ -23,7 +23,7 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Component id="mainTabbedPane" pref="669" max="32767" attributes="0"/>
+          <Component id="mainTabbedPane" max="32767" attributes="0"/>
           <Component id="keyItemPanel" alignment="0" max="32767" attributes="0"/>
           <Component id="partyPanel" alignment="0" max="32767" attributes="0"/>
           <Group type="102" alignment="1" attributes="0">

--- a/src/main/java/sg4e/maikatracker/MaikaTracker.java
+++ b/src/main/java/sg4e/maikatracker/MaikaTracker.java
@@ -1494,9 +1494,9 @@ public class MaikaTracker extends javax.swing.JFrame {
         flagErrorLabel.setText("");
         try {
         if(flagsTextField.getText().startsWith("b"))
-            flagset = FlagSet.fromBinary(flagsTextField.getText());
+            flagset = FlagSet.fromBinary(flagsTextField.getText().trim());
         else
-            flagset = FlagSet.fromString(flagsTextField.getText());
+            flagset = FlagSet.fromString(flagsTextField.getText().trim());
         }
         catch (IllegalArgumentException ex) {
             flagErrorLabel.setText(ex.getMessage());

--- a/src/main/java/sg4e/maikatracker/MaikaTracker.java
+++ b/src/main/java/sg4e/maikatracker/MaikaTracker.java
@@ -568,6 +568,20 @@ public class MaikaTracker extends javax.swing.JFrame {
                 case MIST:
                     createLocationPanel(l, (flagset == null || flagset.contains("Nk")) && dmistLabel.isActive());
                     break;
+                case KOKKOL:
+                    createLocationPanel(l, flagset == null || flagset.contains("V1"));
+                    break;
+                case ZEROMUS:
+                    break;
+                    
+                case FABUL:
+                    createLocationPanel(l, flagset == null || flagset.contains("K"));
+                    break;
+                    
+                case BARON_CASTLE:
+                    createLocationPanel(l, flagset == null || flagset.contains("K") || flagset.contains("Pk"));
+                    break;
+                    
                 default:
                     createLocationPanel(l, true);
                     break;
@@ -631,6 +645,18 @@ public class MaikaTracker extends javax.swing.JFrame {
             knownLocations.add(KeyItemLocation.OGOPOGO);
             knownLocations.add(KeyItemLocation.WYVERN);
         }
+        
+        if (flagset != null && !flagset.contains("K")) {
+            knownLocations.add(KeyItemLocation.FABUL);
+            if(!flagset.contains("Pk"))
+                knownLocations.add(KeyItemLocation.BARON_CASTLE);
+        }
+        
+        if (flagset != null && !flagset.contains("V1"))
+            knownLocations.add(KeyItemLocation.KOKKOL);
+        
+        //Always.  Crystal location set there automatically on K0 seeds.
+        knownLocations.add(KeyItemLocation.ZEROMUS);
         
         Arrays.stream(KeyItemLocation.values())
                 .filter(ki -> !knownLocations.contains(ki))


### PR DESCRIPTION
* When V1 is declared, automatically mark the crystal as being at
Kokkol's Shop, with logic reminding you to go there, once you have both
the Adamant and Legend Sword.
* When K0 is specified, in other words, no Key Item randomization,
auto-specify the locations of ALL key items, with Crystal being at
either Zeromus or Kokkol's depending on if its V1 or not,  and Pass at
baron castle, if Pk is specified.  These key item auto-specifications
happen on reset of key item location under those flag conditions.