### PR TITLE
Master

### DIFF
--- a/src/main/java/sg4e/maikatracker/ChestLabel.java
+++ b/src/main/java/sg4e/maikatracker/ChestLabel.java
@@ -44,10 +44,13 @@ public class ChestLabel extends JLabel {
     private static final String TEXT_KNOWN = "✓";
     private static final ImageIcon checked, unchecked;
     
+    private final MaikaTracker tracker;
+    
     private State state;
     private TreasureChest chest;
     private KeyItemMetadata keyItemContents;
     private ImageIcon active, deactive;
+    private KeyItemPanel keyItemPanel;
     
     static {
         String uncheckedUrl = "maps/unchecked.png";
@@ -74,6 +77,7 @@ public class ChestLabel extends JLabel {
     }
     
     public ChestLabel() {
+        tracker = MaikaTracker.tracker;
         setOpaque(false);
         setPreferredSize(new Dimension(TreasureChest.PIXELS_PER_SQUARE, TreasureChest.PIXELS_PER_SQUARE));
         setHorizontalAlignment(SwingConstants.CENTER);
@@ -99,8 +103,6 @@ public class ChestLabel extends JLabel {
                     }
                 }
                 else if(SwingUtilities.isRightMouseButton(e)) {
-                    MaikaTracker tracker = MaikaTracker.getTrackerFromChild(ChestLabel.this);
-
                     JPopupMenu menu;
                     if(keyItemContents == null || !tracker.isResetOnly())
                     {
@@ -108,7 +110,6 @@ public class ChestLabel extends JLabel {
                             if(keyItemContents != null)
                                 tracker.resetKeyItemLocation(keyItemContents, chest.getId());
                             tracker.updateKeyItemLocation(ki, chest.getId());
-                            keyItemContents = ki;
                         });
                     }
                     else {
@@ -127,7 +128,7 @@ public class ChestLabel extends JLabel {
         });
     }
     
-    private void setUnchecked() {
+    public void setUnchecked() {
         setBackground(COLOR_UNKNOWN);
         if(deactive == null)
             setText(TEXT_UNKNOWN);
@@ -135,9 +136,11 @@ public class ChestLabel extends JLabel {
             setIcon(deactive);
         setForeground(Color.WHITE);
         state = State.UNCHECKED;
+        if(keyItemPanel != null)
+            keyItemPanel.setActive(false);
     }
     
-    private void setChecked() {
+    public void setChecked() {
         setBackground(COLOR_KNOWN);        
         if(active == null)
             setText(TEXT_KNOWN);
@@ -145,10 +148,17 @@ public class ChestLabel extends JLabel {
             setIcon(active);
         setForeground(Color.BLACK);
         state = State.CHECKED;
+        if(keyItemPanel != null)
+            keyItemPanel.setActive(true);
     }
     
-    public void setKeyItem(KeyItemMetadata ki) {
+    public String getId() {
+        return chest.getId();
+    }
+    
+    public ChestLabel setKeyItem(KeyItemMetadata ki) {
         keyItemContents = ki;
+        keyItemPanel = tracker.getPanelForKeyItem(ki);
         setText(null);
         setToolTipText(ki.getEnum().toString());
         active = new ImageIcon(ki.getColorIcon().getImage().getScaledInstance(
@@ -159,6 +169,7 @@ public class ChestLabel extends JLabel {
             setUnchecked();
         else
             setChecked();
+        return this;
     }
     
     public void clearKeyItem() {
@@ -166,6 +177,10 @@ public class ChestLabel extends JLabel {
         active = checked;
         deactive = unchecked;
         keyItemContents = null;
+        if(keyItemPanel != null) {
+            keyItemPanel.setActive(false);
+            keyItemPanel = null;
+        }
         if(state == State.UNCHECKED)
             setUnchecked();
         else

--- a/src/main/java/sg4e/maikatracker/KeyItemPanel.java
+++ b/src/main/java/sg4e/maikatracker/KeyItemPanel.java
@@ -36,7 +36,8 @@ import sg4e.ff4stats.fe.KeyItemLocation;
  * @author sg4e
  */
 public class KeyItemPanel extends JPanel {
-    private final JLabel itemImage;
+    private final MaikaTracker tracker;
+    private final StativeLabel itemImage;
     private final KeyItemMetadata metadata;
     private final JLabel locationLabel;
     private KeyItemLocation location = null;
@@ -46,6 +47,7 @@ public class KeyItemPanel extends JPanel {
     private boolean resetting;
     
     public KeyItemPanel(KeyItemMetadata meta) {
+        tracker = MaikaTracker.tracker;
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
         metadata = meta;
         itemImage = new StativeLabel(metadata.getGrayIcon(), metadata.getColorIcon());
@@ -54,15 +56,22 @@ public class KeyItemPanel extends JPanel {
             @Override
             public void mouseClicked(MouseEvent e) {
                 if(SwingUtilities.isLeftMouseButton(e)) {
-                    MaikaTracker.getTrackerFromChild(KeyItemPanel.this).updateKeyItemCountLabel();
-                    MaikaTracker.getTrackerFromChild(KeyItemPanel.this).updateLogic();
+                    tracker.updateKeyItemCountLabel();
+                    if(location != null) {
+                        if (isAcquired())
+                            tracker.locationsVisited.add(location);
+                        else
+                            tracker.locationsVisited.remove(location);
+                    }
+                    else if (isInChest()) {
+                        // TODO: Add chest set/clear logic
+                    }
+                    tracker.updateLogic();
                 }
                 if(SwingUtilities.isRightMouseButton(e)) {
-                    JPopupMenu locationMenu;
-                    MaikaTracker tracker = MaikaTracker.getTrackerFromChild(KeyItemPanel.this);
+                    JPopupMenu locationMenu;                    
                     if(!isKnown() || !tracker.isResetOnly()) {
-                        locationMenu = ((MaikaTracker)SwingUtilities.getWindowAncestor(KeyItemPanel.this))
-                                .getAvailableLocationsMenu(loc -> setLocation(loc));
+                        locationMenu = tracker.getAvailableLocationsMenu(loc -> setLocation(loc));
                         locationMenu.add(new JSeparator(), 0);
                         JMenuItem custom = new JMenuItem("Chest location");
                         custom.addActionListener((ae) -> {
@@ -114,12 +123,21 @@ public class KeyItemPanel extends JPanel {
         add(locationLabel, BorderLayout.CENTER);
     }
     
+    public void setActive(boolean on) {
+        itemImage.setActive(on);
+    }
+    
     public void setLocation(KeyItemLocation loc) {
         if(isKnown())
             reset();
         location = loc;
         locationLabel.setText(loc.getAbbreviatedLocation());
         locationLabel.setToolTipText(loc.getLocation());
+        if(isAcquired())
+            tracker.locationsVisited.add(loc);
+        else
+            tracker.locationsVisited.remove(loc);
+        tracker.updateLogic();
     }
     
     public void setTextColor(Color color) {
@@ -163,9 +181,12 @@ public class KeyItemPanel extends JPanel {
         if(resetting) return;
         resetting = true;
         
-        MaikaTracker tracker = MaikaTracker.getTrackerFromChild(KeyItemPanel.this);
         if (location == null && tracker.getAtlas().hasChestId(locationLabel.getText())) {
             tracker.resetKeyItemLocation(metadata, locationLabel.getText());
+        }
+        
+        if (location != null) {
+            tracker.locationsVisited.remove(location);
         }
 
         locationLabel.setText(UNKNOWN_LOCATION);
@@ -241,7 +262,7 @@ public class KeyItemPanel extends JPanel {
         }
         else if(tracker.flagset.contains("V1") && metadata.equals(KeyItemMetadata.CRYSTAL))
             setLocation(KeyItemLocation.KOKKOL);
-        
+        tracker.updateLogic();
         
         resetting = false;
     }

--- a/src/main/java/sg4e/maikatracker/KeyItemPanel.java
+++ b/src/main/java/sg4e/maikatracker/KeyItemPanel.java
@@ -41,6 +41,7 @@ public class KeyItemPanel extends JPanel {
     private final KeyItemMetadata metadata;
     private final JLabel locationLabel;
     private KeyItemLocation location = null;
+    private ChestLabel chestLabel = null;
     
     private static final String UNKNOWN_LOCATION = "?";
     
@@ -64,7 +65,10 @@ public class KeyItemPanel extends JPanel {
                             tracker.locationsVisited.remove(location);
                     }
                     else if (isInChest()) {
-                        // TODO: Add chest set/clear logic
+                        if (isAcquired())
+                            chestLabel.setChecked();
+                        else
+                            chestLabel.setUnchecked();
                     }
                     tracker.updateLogic();
                 }
@@ -158,19 +162,20 @@ public class KeyItemPanel extends JPanel {
     }
     
     public boolean isKnown() {
-        return location != null || !UNKNOWN_LOCATION.equals(locationLabel.getText());
+        return location != null || chestLabel != null;
     }
     
     public boolean isInChest() {
-        return location == null && !UNKNOWN_LOCATION.equals(locationLabel.getText());
+        return location == null && chestLabel != null;
     }
     
     public KeyItemMetadata getKeyItem() {
         return metadata;
     }
     
-    public void setLocationInChest(String chestId) {
-        locationLabel.setText(chestId);
+    public void setLocationInChest(ChestLabel label) {
+        chestLabel = label;
+        locationLabel.setText(label.getId());
     }
     
     public void reset() {
@@ -181,8 +186,10 @@ public class KeyItemPanel extends JPanel {
         if(resetting) return;
         resetting = true;
         
-        if (location == null && tracker.getAtlas().hasChestId(locationLabel.getText())) {
-            tracker.resetKeyItemLocation(metadata, locationLabel.getText());
+        if (isInChest()) {
+            chestLabel.clearKeyItem();
+            chestLabel.setUnchecked();
+            chestLabel = null;
         }
         
         if (location != null) {

--- a/src/main/java/sg4e/maikatracker/MaikaTracker.form
+++ b/src/main/java/sg4e/maikatracker/MaikaTracker.form
@@ -712,7 +712,7 @@
                 </Component>
                 <Component class="javax.swing.JButton" name="resetButton">
                   <Properties>
-                    <Property name="text" type="java.lang.String" value="Reset"/>
+                    <Property name="text" type="java.lang.String" value="Reset &amp; Apply Flags"/>
                   </Properties>
                   <Events>
                     <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="resetButtonActionPerformed"/>

--- a/src/main/java/sg4e/maikatracker/MaikaTracker.java
+++ b/src/main/java/sg4e/maikatracker/MaikaTracker.java
@@ -1254,7 +1254,7 @@ public class MaikaTracker extends javax.swing.JFrame {
 
         resetLabel.setText("<html>Are you sure you would like to reset everything?<br> <br> This Action cannot be undone");
 
-        resetButton.setText("Reset");
+        resetButton.setText("Reset & Apply Flags");
         resetButton.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 resetButtonActionPerformed(evt);

--- a/src/main/java/sg4e/maikatracker/MaikaTracker.java
+++ b/src/main/java/sg4e/maikatracker/MaikaTracker.java
@@ -622,6 +622,15 @@ public class MaikaTracker extends javax.swing.JFrame {
     
     public JPopupMenu getAvailableLocationsMenu(Consumer<KeyItemLocation> actionOnEachItem) {
         JPopupMenu locationMenu = new JPopupMenu("Locations");
+        
+        List<KeyItemLocation> dLunar = Arrays.stream(keyItemPanel.getComponents())
+                .map(c -> (KeyItemPanel) c)
+                .map(KeyItemPanel::getItemLocation)
+                .filter(Objects::nonNull)
+                .filter(ki -> ki.equals(KeyItemLocation.DLUNAR))
+                .collect(Collectors.toList());               
+        
+        
         Set<KeyItemLocation> knownLocations = Arrays.stream(keyItemPanel.getComponents())
                 .map(c -> (KeyItemPanel) c)
                 .map(KeyItemPanel::getItemLocation)
@@ -649,6 +658,8 @@ public class MaikaTracker extends javax.swing.JFrame {
             knownLocations.add(KeyItemLocation.OGOPOGO);
             knownLocations.add(KeyItemLocation.WYVERN);
         }
+        else if(dLunar.size() < 2)
+            knownLocations.remove(KeyItemLocation.DLUNAR);
         
         if (flagset != null && !flagset.contains("K")) {
             knownLocations.add(KeyItemLocation.FABUL);

--- a/src/main/java/sg4e/maikatracker/MaikaTracker.java
+++ b/src/main/java/sg4e/maikatracker/MaikaTracker.java
@@ -518,9 +518,9 @@ public class MaikaTracker extends javax.swing.JFrame {
     
     public void updateKeyItemLocation(KeyItemMetadata keyItem, String chestId) {
         //first, find the KeyItemPanel
-        getPanelForKeyItem(keyItem).setLocationInChest(chestId);
+        KeyItemPanel panel = getPanelForKeyItem(keyItem);        
         //then, update the chest in the atlas
-        atlas.setChestContents(chestId, keyItem);
+        panel.setLocationInChest(atlas.setChestContents(chestId, keyItem));
     }
     
     public void createLocationPanel(KeyItemLocation l, Boolean createIfTrue) {
@@ -623,8 +623,8 @@ public class MaikaTracker extends javax.swing.JFrame {
         return (MaikaTracker) SwingUtilities.getWindowAncestor(child);
     }
     
-    private KeyItemPanel getPanelForKeyItem(KeyItemMetadata keyItem) {
-        return Arrays.stream(keyItemPanel.getComponents())
+    public KeyItemPanel getPanelForKeyItem(KeyItemMetadata keyItem) {
+        return keyItem == null ? null : Arrays.stream(keyItemPanel.getComponents())
                 .map(c -> (KeyItemPanel) c)
                 .filter(kip -> keyItem.equals(kip.getKeyItem()))
                 .findAny()
@@ -1457,7 +1457,7 @@ public class MaikaTracker extends javax.swing.JFrame {
         getContentPane().setLayout(layout);
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(mainTabbedPane, javax.swing.GroupLayout.DEFAULT_SIZE, 669, Short.MAX_VALUE)
+            .addComponent(mainTabbedPane)
             .addComponent(keyItemPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
             .addComponent(partyPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
             .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()

--- a/src/main/java/sg4e/maikatracker/MaikaTracker.java
+++ b/src/main/java/sg4e/maikatracker/MaikaTracker.java
@@ -76,8 +76,7 @@ public class MaikaTracker extends javax.swing.JFrame {
     
     private static final Logger LOG = LogManager.getLogger();
     
-    private final TreasureAtlas atlas = new TreasureAtlas();
-    private final Set<KeyItemLocation> locationsVisited = new HashSet<>();
+    private final TreasureAtlas atlas = new TreasureAtlas();    
     private static final String TOWER_OF_ZOT = "Zot";
     private static final String EBLAN_CASTLE = "Eblan Castle";
     private static final String EBLAN_CAVE = "Eblan Cave";
@@ -101,13 +100,18 @@ public class MaikaTracker extends javax.swing.JFrame {
     private final Preferences prefs;
     private static final String RESET_ONLY_ID = "AllowResetOnlyWhenKeyItemSet";
     
+    public final Set<KeyItemLocation> locationsVisited = new HashSet<>();
+    
     public FlagSet flagset = null;
+    
+    public static MaikaTracker tracker;
 
     /**
      * Creates new form MaikaTracker
      */
     public MaikaTracker() {
-        initComponents();
+        tracker = this;
+        initComponents();        
         prefs = Preferences.userRoot().node(this.getClass().getName());
         Map<Battle, Formation> bosses = Battle.getAllBosses();
         List<String> bossNames = bosses.keySet().stream().map(Battle::getBoss).distinct().collect(Collectors.toList());
@@ -430,8 +434,9 @@ public class MaikaTracker extends javax.swing.JFrame {
         //shopPanel2.setVisible(false);
         
         updateKeyItemCountLabel();
-        applyFlagsButtonActionPerformed(null);
+        resetButtonActionPerformed(null);
         updateLogic();
+        mainTabbedPane.setSelectedComponent(resetPane);
         
         setTitle("MaikaTracker");
         pack();
@@ -528,6 +533,12 @@ public class MaikaTracker extends javax.swing.JFrame {
         }
 
         panel.setButtonListener((ae) -> {
+            Arrays.stream(keyItemPanel.getComponents())
+                .map(c -> (KeyItemPanel) c)
+                .filter(ki -> ki.getItemLocation() != null)
+                .filter(ki -> ki.getItemLocation().equals(panel.getKeyItemLocation()))
+                .forEach(ki -> ki.setActive(true));
+            
             locationsVisited.add(panel.getKeyItemLocation());
             logicPanel.remove(panel);
             logicPanel.revalidate();

--- a/src/main/java/sg4e/maikatracker/ShopPanel.java
+++ b/src/main/java/sg4e/maikatracker/ShopPanel.java
@@ -114,12 +114,81 @@ public class ShopPanel extends javax.swing.JPanel {
     }
     
     public static void reset() {
+        final FlagSet flagset = MaikaTracker.tracker.flagset;
+        final Boolean cabinsOnly = flagset != null && flagset.contains("Sc");
+        final Boolean emptyShop = flagset != null && flagset.contains("Sx");
+        final Boolean vanillaShop = flagset != null 
+                && !flagset.contains("S1") && !flagset.contains("S2")
+                && !flagset.contains("S3") && !flagset.contains("S4")
+                && !cabinsOnly && !emptyShop;
+        final Boolean pass = flagset == null || flagset.contains("Ps");
+        final Boolean jItems = flagset == null || flagset.contains("Ji");
         shopPanels.forEach(panel -> {
-            for (JCheckBox box : getCheckBoxes(panel)) {
+            getCheckBoxes(panel).forEach((box) -> {
                 box.setSelected(false);
-                if(!itemLocations.get(box.getText()).isEmpty())
-                    itemLocations.get(box.getText()).clear();
+            });
+            
+            if(vanillaShop) {
+                switch(panel.shopLocation) {
+                    case "Dwarf Castle":
+                    case "Feymarch":
+                    case "Tomara":
+                    case "Mysidia":
+                        panel.cabin.setSelected(true);
+                        panel.cure2.setSelected(true);
+                    case "Agart":
+                    case "Baron":
+                    case "Fabul":
+                    case "Kaipo":
+                    case "Troia [Item]":
+                        panel.cure1.setSelected(true);
+                        panel.life.setSelected(true);
+                        panel.tent.setSelected(true);
+                        panel.ether1.setSelected(!jItems);                    
+                        break;
+                        
+                    case "Eblan Cave":
+                        panel.cure1.setSelected(!jItems);
+                        panel.cure2.setSelected(!jItems);
+                        panel.tent.setSelected(!jItems);
+                        panel.cabin.setSelected(!jItems);
+                        panel.life.setSelected(!jItems);
+                        panel.ether1.setSelected(!jItems);
+                        break;
+                        
+                    case "Silvera":
+                        break;
+                        
+                    case "Troia [Pub]":
+                        panel.pass.setSelected(pass);
+                        break;
+                        
+                    case "Hummingway":
+                        panel.cure2.setSelected(true);
+                        panel.life.setSelected(true);
+                        panel.ether1.setSelected(true);
+                        panel.ether2.setSelected(true);
+                        panel.elixir.setSelected(true);
+                        panel.cabin.setSelected(true);
+                        break;
+                }
             }
+            
+            getCheckBoxes(panel).forEach((box) -> {
+                if(box.isSelected())
+                    itemLocations.get(box.getText()).add(panel.shopLocation);
+                else
+                    itemLocations.get(box.getText()).remove(panel.shopLocation);
+
+                if (knownLocationsPanel != null) {
+                    getCheckBoxes(knownLocationsPanel).stream()
+                        .filter(c -> c.getText().equals(box.getText()))
+                        .collect(Collectors.toList()).forEach((b) -> {
+                            b.setSelected(!itemLocations.get(box.getText()).isEmpty());
+                    });
+                }                    
+            });
+            
         });
         UpdateToolTips();
     }

--- a/src/main/java/sg4e/maikatracker/StativeLabel.java
+++ b/src/main/java/sg4e/maikatracker/StativeLabel.java
@@ -61,6 +61,10 @@ public class StativeLabel extends JLabel {
         setIcon(deactive);
     }
     
+    public void setActive(boolean on) {
+        setIcon(on ? active : deactive);
+    }
+    
     public boolean isActive() {
         return getIcon() == active;
     }

--- a/src/main/java/sg4e/maikatracker/TreasureAtlas.java
+++ b/src/main/java/sg4e/maikatracker/TreasureAtlas.java
@@ -64,9 +64,9 @@ public class TreasureAtlas extends JPanel {
         dungeonToFloors.forEach((mid, map) -> { map.forEach((tid, tmap) -> {tmap.reset();}); });
     }
     
-    public void setChestContents(String chestId, KeyItemMetadata ki) {
+    public ChestLabel setChestContents(String chestId, KeyItemMetadata ki) {
         Page page = chestIdToPage.get(chestId);
-        getTreasureMap(page).setChestContents(chestId, ki);
+        return getTreasureMap(page).setChestContents(chestId, ki);
     }
     
     public void clearChestContents(String chestId) {

--- a/src/main/java/sg4e/maikatracker/TreasureMap.java
+++ b/src/main/java/sg4e/maikatracker/TreasureMap.java
@@ -81,9 +81,9 @@ public class TreasureMap extends JPanel {
         return new ArrayList<>(chests);
     }
     
-    public void setChestContents(String chestId, KeyItemMetadata keyItem) {
+    public ChestLabel setChestContents(String chestId, KeyItemMetadata keyItem) {
         TreasureChest chest = getChest(chestId);
-        cells[chest.getX()][chest.getY()].setKeyItem(keyItem);
+        return cells[chest.getX()][chest.getY()].setKeyItem(keyItem);
     }
     
     public void clearChestContents(String chestId) {


### PR DESCRIPTION
* Fixed issue where it is not possible to specify the D-Lunar location for two different key items.
* Reset button now idicates that it also applies the flags.
* Key item collection state now reflects checked logic state / treasure chest map state, where applicable, and vice-versa.
* Shop tracker now shows where everything is, when shops are S0.