### PR TITLE
Migrate logging to Log4j2 SLF4J binding and update JAR packaging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-core:2.25.2'
     implementation 'org.apache.logging.log4j:log4j-api:2.25.2'
     annotationProcessor 'org.apache.logging.log4j:log4j-core:2.25.2'
-    implementation 'org.slf4j:slf4j-log4j12:1.7.36'
+    implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.25.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.20.1'
     implementation 'com.google.guava:guava:33.6.0-jre'
     implementation 'com.github.sg4e:FF4StatsLib:master-SNAPSHOT'
@@ -44,8 +44,12 @@ application {
 }
 
 jar {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     manifest {
-        attributes 'Main-Class': application.mainClass.get()
+        attributes(
+            'Main-Class': application.mainClass.get(),
+            'Multi-Release': 'true'
+        )
     }
 
     from {

--- a/src/main/java/sg4e/maikatracker/MaikaTracker.java
+++ b/src/main/java/sg4e/maikatracker/MaikaTracker.java
@@ -73,7 +73,6 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.border.TitledBorder;
 import javax.swing.filechooser.FileFilter;
 import javax.swing.table.TableModel;
-import org.apache.log4j.BasicConfigurator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import sg4e.ff4stats.fe.FlagSet;
@@ -2687,7 +2686,6 @@ public final class MaikaTracker extends javax.swing.JFrame {
         }
         /* Create and display the form */
         java.awt.EventQueue.invokeLater(() -> {
-            BasicConfigurator.configure();
             new MaikaTracker().setVisible(true);
             tracker.flagsTextField.setText(String.join(" ", args));
             tracker.resetButton.doClick();            


### PR DESCRIPTION
### Motivation

- Replace legacy Log4j 1.x configuration with Log4j2-backed SLF4J implementation to modernize logging and avoid mixing logging frameworks.
- Prevent duplicate entries in the assembled fat JAR and enable multi-release metadata for Java runtime compatibility.

### Description

- Replaced `org.slf4j:slf4j-log4j12:1.7.36` with `org.apache.logging.log4j:log4j-slf4j-impl:2.25.2` in `build.gradle` to bind SLF4J to Log4j2.
- Removed the `BasicConfigurator.configure()` call and the `org.apache.log4j.BasicConfigurator` import from `MaikaTracker.java` so Log4j1 configuration is no longer used and Log4j2 via SLF4J drives logging.
- Updated JAR task in `build.gradle` to set `duplicatesStrategy = DuplicatesStrategy.EXCLUDE` and added the `Multi-Release: 'true'` manifest attribute while reorganizing manifest attributes formatting.
- Kept existing dependencies and source/target compatibility settings and preserved runtime classpath assembly logic for creating the distributable JAR.

### Testing

- Ran `./gradlew build` to assemble the project and run unit tests, and the build completed successfully with tests passing.
- Verified the fat JAR is produced and contains the updated manifest and duplicate exclusion settings by running the assemble task locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a180353083c832dadca1cd64e6c580a)