### PR TITLE
Add artifact attestation to GitHub release workflow

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -48,6 +48,8 @@ jobs:
 
     permissions:
       contents: write
+      attestations: write
+      id-token: write
 
     steps:
       - name: Check out MaikaTracker
@@ -93,3 +95,8 @@ jobs:
           files: MaikaTracker/build/libs/MaikaTracker.jar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: MaikaTracker/build/libs/MaikaTracker.jar


### PR DESCRIPTION
### Motivation
- Enable GitHub artifact attestations for release artifacts to improve provenance and supply-chain integrity.

### Description
- Add `attestations: write` and `id-token: write` to the `release` job permissions and add a `Generate artifact attestation` step that uses `actions/attest-build-provenance@v3` with `subject-path: MaikaTracker/build/libs/MaikaTracker.jar`.

### Testing
- Validated the updated workflow YAML by inspecting the diff and file contents (`git diff` and `nl -ba`) and confirmed the workflow file was updated without syntax errors; no workflow run was executed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18141c2710832da373732191a5989d)