### PR TITLE
Use Shadow plugin to produce fat JAR and simplify jar task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'application'
     id 'com.google.protobuf' version '0.9.4'
+    id 'com.gradleup.shadow' version '8.3.9'
 }
 
 java {
@@ -41,21 +42,20 @@ application {
     mainClass = 'sg4e.maikatracker.MaikaTracker'
 }
 
-jar {
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+tasks.named('jar', Jar) {
+    archiveClassifier = 'plain'
+    dependsOn tasks.named('shadowJar')
+}
+
+tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+    archiveClassifier = ''
+    mergeServiceFiles()
+
     manifest {
         attributes(
             'Main-Class': application.mainClass.get(),
             'Multi-Release': 'true'
         )
-    }
-
-    dependsOn ':FF4StatsLib:jar'
-
-    from {
-        configurations.runtimeClasspath
-            .findAll { it.exists() }
-            .collect { it.isDirectory() ? it : zipTree(it) }
     }
 }
 


### PR DESCRIPTION
### Motivation
- Replace the manual runtime classpath unpacking and custom jar assembly with the Gradle Shadow plugin to produce a proper fat JAR and handle service file merging and duplicates.

### Description
- Add the `com.gradleup.shadow` plugin and configure `shadowJar` to produce the primary distributable JAR with `mergeServiceFiles()` and the existing manifest attributes.
- Reconfigure the standard `jar` task to produce a `plain` classifier and depend on `shadowJar` so the shadowed artifact becomes the default output.
- Remove the previous custom `from { configurations.runtimeClasspath ... }` jar assembly and the explicit `dependsOn ':FF4StatsLib:jar'` packaging logic.

### Testing
- Ran `./gradlew clean shadowJar build` to verify the shadow JAR is produced and the project builds successfully, and unit tests executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a196a823cd8832da04cc51cab7e57a9)