### PR TITLE
Add developer documentation: architecture, flag-versioning, and SNI autotracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ The `.jar` binary will be output to `MaikaTracker/build/libs`.
 
 For now, MaikaTracker logs all error output to `stdout`. MaikaTracker can be run from command line as `java -jar MaikaTracker.jar`.
 
+## Developer documentation
+
+Detailed architecture, flag-versioning, persistence, build, and SNI autotracking documentation is available in [`docs/README.md`](docs/README.md).
+
 ## Code contributions
 
 MaikaTracker is a project I enjoy working on and experimenting with new features as I come up with ideas playing FF4FE. Pull requests for bug fixes are appreciated, but pull requests with new features or redesign may be declined if they may be hard to maintain with features in new releases or simply because I have an idea for a different approach I'd like to take on in the future. Developers are more than welcome to fork and share their own variations of MaikaTracker as indicated in the [license](https://github.com/sg4e/MaikaTracker/blob/master/LICENSE.txt).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,40 @@
+# MaikaTracker developer documentation
+
+This directory documents MaikaTracker as it exists in this repository. It is intended for maintainers who need to change the application without first reverse-engineering its Swing form, FF4FE compatibility rules, save format, or SNI integration.
+
+## Reading order
+
+1. [Architecture](architecture.md) — the layers, control flow, ownership boundaries, and repository map.
+2. [Flag versioning](flag-versioning.md) — how FF4FE flag specifications are parsed, classified, queried, persisted, and used for compatibility behavior.
+3. [SNI autotracking](sni-autotracking.md) — the complete SNI communication flow, address-space handling, monitored memory layout, bit semantics, threading, and failure behavior.
+4. [State, imports, and resources](state-and-data.md) — JSON state, spoiler-log imports, preferences, images, maps, and generated Swing forms.
+5. [Build, test, and maintenance](development.md) — local setup, generated sources, tests, release flow, and change checklists.
+
+## Important terminology
+
+- **FF4FE**: Final Fantasy IV: Free Enterprise, the randomizer whose run state MaikaTracker displays.
+- **Flag specification version**: the version encoded by an FF4FE flagset, such as the legacy `0.3.x` family or the newer family. This controls which flag names and meanings the tracker uses.
+- **Tracker-state version**: the `version` field in a saved MaikaTracker JSON file. It is currently `1.0` and is independent of the FF4FE flag specification version.
+- **SNI**: the gRPC service through which MaikaTracker discovers a connected emulator/device and reads game memory.
+- **SNES A-bus address**: a CPU-visible 24-bit SNES address such as `$7E1500` or `$707080`. It is not necessarily the same numeric address used by a device backend.
+
+## High-level data flow
+
+```text
+manual clicks / JSON state / spoiler log / SNI memory
+                         |
+                         v
+                    MaikaTracker
+       +-----------------+------------------+
+       |                 |                  |
+       v                 v                  v
+ key-item/boss/party   logic model      maps and shops
+ Swing components      (FF4StatsLib)    Swing components
+       |                 |                  |
+       +-----------------+------------------+
+                         |
+                         v
+                rendered tracker window
+```
+
+MaikaTracker is deliberately stateful: most current run state lives directly in Swing component instances, with `MaikaTracker` coordinating updates. There is no separate application-wide immutable model. That fact is central to understanding save/load, autotracking, and testing.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,180 @@
+# Architecture
+
+## 1. System overview
+
+MaikaTracker is a Java 8 desktop application built with Swing and Gradle. Its main class, `sg4e.maikatracker.MaikaTracker`, is both the top-level `JFrame` and the application coordinator. It constructs the UI, owns shared services, reacts to input, performs logic updates, and serializes state.
+
+The project is best understood as the following layers. These are conceptual layers rather than strictly enforced packages.
+
+```text
++------------------------------------------------------------------+
+| Application shell: MaikaTracker JFrame and NetBeans form          |
++-----------------------+----------------------+---------------------+
+| Interactive widgets   | Run logic            | Data integration    |
+| key items, bosses,    | accessibility, flags | JSON, spoiler logs, |
+| party, shops, maps    | XP calculations      | preferences, SNI    |
++-----------------------+----------------------+---------------------+
+| Project data/model helpers and FF4StatsLib domain objects          |
++------------------------------------------------------------------+
+| Swing / Jackson / gRPC+protobuf / Glazed Lists / Log4j             |
++------------------------------------------------------------------+
+```
+
+## 2. Repository map
+
+| Path | Responsibility |
+| --- | --- |
+| `src/main/java/sg4e/maikatracker/MaikaTracker.java` | Main window, composition root, event handlers, logic updates, state load/save, spoiler parsing, XP tools, preferences, and SNI snapshot application. |
+| `src/main/java/sg4e/maikatracker/*.form` | NetBeans GUI Builder source. Generated sections in corresponding Java files must remain GUI Builder compatible. |
+| `src/main/java/sg4e/maikatracker/autotracking/` | SNI transport abstraction, gRPC implementation, poll service, memory decoder, mappings, and immutable snapshot. |
+| `src/main/proto/sni/sni.proto` | Local SNI protobuf/gRPC contract used to generate Java stubs. It declares more SNI services than MaikaTracker currently calls. |
+| `src/main/resources/` | Runtime images for bosses, key items, characters, maps, and chest markers. |
+| `src/test/java/sg4e/maikatracker/autotracking/` | Unit tests for poll enable/error behavior and basic bit decoding. |
+| `build.gradle` | Java/application/protobuf plugins, dependencies, generated gRPC configuration, and fat-JAR assembly. |
+| `settings.gradle` | Declares `FF4StatsLib` as a sibling Gradle project at `../FF4StatsLib`. |
+| `.github/workflows/build_and_release.yml` | CI tests and timestamped release-JAR publication from `master`. |
+
+## 3. Composition and startup
+
+`MaikaTracker.main` installs the Nimbus look and feel when available and opens a `MaikaTracker` on the Swing event-dispatch thread (EDT). The constructor is the composition root:
+
+1. It initializes NetBeans-generated Swing components.
+2. It opens the application's `java.util.prefs.Preferences` node.
+3. It creates an `SniGrpcMemoryReader`, `SniTrackerDecoder`, and `SniAutoTrackerService`.
+4. It populates party, boss, map, shop, and key-item widgets.
+5. It restores visual and behavioral preferences.
+6. It enables or disables the SNI poller according to the saved preference.
+
+The SNI service creates its scheduler immediately, but polling is a no-op until enabled. See [SNI autotracking](sni-autotracking.md).
+
+## 4. Application shell and coordination layer
+
+`MaikaTracker` is the central coordinator and a globally reachable singleton through `MaikaTracker.tracker`. Child classes use either this static reference or `getTrackerFromChild` to reach the frame. Its responsibilities include:
+
+- constructing and navigating all tabs and panels;
+- owning the current `FlagSet`, `TreasureAtlas`, visited-location set, and SNI service;
+- translating flags into UI visibility and logic behavior;
+- coordinating key-item locations, chests, shops, and the accessible-location panel;
+- saving/loading JSON and importing FF4FE spoiler logs;
+- maintaining user preferences such as colors, directories, checked-icon behavior, and autotracking enablement;
+- calculating party XP and boss information through FF4StatsLib.
+
+This makes changes convenient but tightly coupled. A change to a child widget can have effects in logic, persistence, and imports because the visible widget state is frequently the source of truth.
+
+## 5. Interactive presentation layer
+
+### 5.1 Stateful labels
+
+`StativeLabel` is the base interaction primitive. It owns an ordered list of icons and an integer icon index. A left click cycles through states. `setActive`, `setState`, and `reset` mutate the same index programmatically. Most tracker state is represented by these icon indices:
+
+- index `0`: unseen/not found/inactive;
+- index `1`: seen/found/active;
+- index `2`: checked/defeated/used when the widget has a checked icon.
+
+`DemoLabel` is a non-clickable legend that demonstrates gray, color, and checked states.
+
+### 5.2 Key items
+
+`KeyItemMetadata` binds each FF4FE key item to:
+
+- its FF4StatsLib `KeyItem` enum;
+- a spoiler-log name;
+- gray/color/checked icons.
+
+`KeyItemPanel` combines a stateful item icon and a location label. It can associate a key item with exactly one of:
+
+- a `KeyItemLocation`;
+- a `ChestLabel` in the treasure atlas;
+- a `ShopPanel`.
+
+Its reset behavior also applies flag-dependent vanilla locations and removes unavailable items. Its context menus let users assign locations, chests, or shops. Because location assignment updates `locationsVisited` and logic, it is not merely presentational.
+
+### 5.3 Bosses
+
+`BossLabel` represents a boss slot/state and supports gray, color, and optionally checked icons. It also carries the boss/slot association used by boss-stat displays and persistence. The class includes image compositing for checked overlays. Boss metadata and calculations come from FF4StatsLib's `Battle` and `Formation` classes.
+
+### 5.4 Party and XP
+
+`PartyLabel` represents one of five party slots and gates available characters according to flags and progression (`MtOrdealsComplete`, `DwarfCastleComplete`). It owns a FF4StatsLib `LevelData`/`PartyMember` relationship.
+
+`PartyTableModel` adapts party members to the XP table. XP calculations and the D. Machin helper are coordinated by `MaikaTracker` and use FF4StatsLib party/stat objects.
+
+### 5.5 Shops
+
+Each `ShopPanel` contains categorized checkboxes. Static collections allow all shops to be updated, reset, recolored, serialized, or restored together. `ShopPanel.UpdateFlags()` has separate branches for legacy and newer FF4FE flag vocabularies. Checkbox `name` metadata encodes categories/tier rules used by this method.
+
+### 5.6 Treasure maps
+
+- `TreasureChest` is an immutable chest ID plus map coordinate.
+- `ChestLabel` is the clickable map marker and can hold a key item.
+- `TreasureMap` renders one floor image and its chest markers.
+- `TreasureAtlas` indexes maps by dungeon/floor and chest ID, supports navigation, and serializes opened chest IDs.
+
+Chest IDs are also used by spoiler-log parsing and key-item persistence, so they form a small stable identifier scheme within the application.
+
+### 5.7 Logic panel
+
+The accessible-location panel is rebuilt by `MaikaTracker.updateLogic()`:
+
+1. collect acquired key-item enums from active key-item panels;
+2. ask `KeyItemLocation.getAccessibleLocations(...)` in FF4StatsLib for candidate locations;
+3. remove `locationsVisited`;
+4. apply MaikaTracker-specific flag gates for summon, lunar, free-item, Fabul, Baron, Kokkól/objective, and Zeromus cases;
+5. create clickable `LocationPanel` entries.
+
+Completing a location adds it to `locationsVisited`, removes its panel, and updates special party progression state for Mt. Ordeals and Dwarf Castle.
+
+## 6. Domain/model layer and FF4StatsLib boundary
+
+MaikaTracker depends on a sibling Gradle project named `FF4StatsLib`. It is not pinned to a Maven artifact or commit by this repository. The sibling provides the domain knowledge that would otherwise be expensive to duplicate:
+
+- FF4FE flag parsing and flag-version definitions (`FlagSet`);
+- key-item accessibility (`KeyItem`, `KeyItemLocation`);
+- boss battle/formations and stats (`Battle`, `Formation`);
+- party members, levels, equipment, and XP-related data.
+
+MaikaTracker adds UI metadata and compatibility policy around those objects. For example, FF4StatsLib determines broadly accessible key-item locations, while `MaikaTracker.updateLogic()` removes already-visited locations and applies tracker-specific flag gates.
+
+**Maintenance implication:** because `settings.gradle` points at `../FF4StatsLib`, two developers can build the same MaikaTracker commit against different FF4StatsLib revisions. Flag parsing and domain behavior can therefore change without a MaikaTracker source change. CI checks out the current FF4StatsLib default branch as well. For reproducible releases, pinning that dependency would be necessary.
+
+## 7. Integration/data layer
+
+### JSON state
+
+`TrackerState` is a Jackson DTO. Saving walks live Swing components and supporting collections to create a snapshot. Loading first applies flags/reset behavior, then mutates widgets and collections from the DTO. See [State and data](state-and-data.md).
+
+### Spoiler logs
+
+The spoiler importer is a positional text parser in `MaikaTracker`. It recognizes specific section headings and fixed-width/content patterns for key-item slots, characters, battles, treasures, and shops. It directly updates the same widgets used by manual tracking.
+
+### Preferences
+
+`java.util.prefs.Preferences` stores user settings outside the JSON run state. These include colors, previously used directories, reset behavior, checked-icon behavior/darkness, and whether autotracking is enabled.
+
+### SNI
+
+The autotracking package is the only network/device integration. It reads four memory ranges, decodes them into project domain values, and sends snapshots to the Swing coordinator. It is read-only: the protobuf contract declares writes, but MaikaTracker never writes to SNI.
+
+## 8. Threading model
+
+- Swing event handlers and manual state changes run on the EDT.
+- `SniAutoTrackerService` polls on one scheduled-executor thread.
+- The poller decodes a complete snapshot off the EDT.
+- `MaikaTracker.applyAutoTrackerSnapshot()` uses `SwingUtilities.invokeLater` before reading or mutating Swing state.
+
+The current architecture assumes that non-SNI state mutations originate on the EDT. New integrations should preserve this boundary.
+
+## 9. Dependency and generated-code layer
+
+Gradle generates Java protobuf messages and gRPC stubs from `src/main/proto/sni/sni.proto`. The application uses blocking stubs over gRPC Netty. The build creates a fat JAR by unpacking runtime dependencies and the sibling FF4StatsLib JAR.
+
+The `.form` files are NetBeans GUI Builder definitions. Sections marked as generated in Java should not be hand-edited unless the result remains compatible with the GUI Builder.
+
+## 10. Architectural risks and extension points
+
+- **Central coordinator:** `MaikaTracker` is large and owns unrelated concerns. Prefer extracting pure decoders/policies rather than adding more parsing to it.
+- **Widget-as-model:** programmatic state changes must update all derived UI/logic state, not just an icon.
+- **Static/global state:** boss lists, party lists, shops, and `MaikaTracker.tracker` make isolated tests difficult.
+- **External unpinned domain library:** validate behavior against the actual sibling FF4StatsLib revision used for a release.
+- **Identifier stability:** enum names, chest IDs, and shop names appear in persisted/imported data. Renaming them requires migration or compatibility handling.
+- **SNI mapping tables:** new ROM-side bits are ignored until explicitly mapped. This is safer than guessing, but requires coordinated updates.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,122 @@
+# Build, test, and maintenance guide
+
+## 1. Prerequisites
+
+- Java/JDK 8 or later; source and target compatibility are Java 8.
+- A sibling checkout of `FF4StatsLib` at `../FF4StatsLib`.
+- The included Gradle wrapper.
+- NetBeans GUI Builder when editing generated Swing layouts.
+- For live autotracking tests, an SNI gRPC server and compatible FF4FE ROM/device.
+
+Expected directory layout:
+
+```text
+parent/
+├── FF4StatsLib/
+└── MaikaTracker/
+```
+
+## 2. Build commands
+
+```sh
+./gradlew test
+./gradlew build
+java -jar build/libs/MaikaTracker.jar
+```
+
+The protobuf plugin runs `protoc` and the gRPC Java generator from versions declared in `build.gradle`. Generated sources live under `build/generated/` and must not be hand-edited or committed.
+
+The JAR task creates a fat executable JAR by unpacking runtime dependencies and includes the sibling FF4StatsLib JAR. Duplicate files are excluded.
+
+## 3. Main dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| FF4StatsLib sibling project | FF4FE flags, key-item logic, boss data, party/stat data. |
+| Swing/JDK | Desktop UI and preferences. |
+| Jackson Databind | JSON run-state save/load. |
+| gRPC Netty/Protobuf/Stub | SNI communication and generated client types. |
+| Glazed Lists | Autocomplete support in boss/position selectors. |
+| Guava | General utility dependency. |
+| Log4j/SLF4J binding | Application and SNI warning/error logging. |
+| JUnit 4 | Tests. |
+
+## 4. Tests
+
+Current automated tests cover only part of the SNI layer:
+
+- disabled poll does not emit;
+- enabled poll reads/decodes/emits;
+- read failure does not emit;
+- basic found/used/checked bit decoding;
+- key-item mapping keys are unique.
+
+Notably absent are automated tests for:
+
+- `SniGrpcMemoryReader` device selection, RPC requests, address modes, and fallback;
+- found-location record decoding;
+- the full checked-location mapping;
+- flag-version compatibility and null semantics;
+- JSON save/load round trips;
+- spoiler-log imports;
+- Swing UI and logic behavior.
+
+Prefer extracting pure functions/policies and adding unit tests when changing these areas.
+
+## 5. CI and release flow
+
+The GitHub Actions workflow:
+
+1. checks out MaikaTracker and FF4StatsLib as siblings;
+2. installs Temurin Java 8;
+3. runs `./gradlew test` for pull requests and pushes to `master`;
+4. on `master`, builds the fat JAR;
+5. creates a timestamp/SHA release and uploads the JAR;
+6. generates build-provenance attestation.
+
+Because FF4StatsLib is checked out without a pinned ref, CI/release behavior can change with its default branch. Investigate both repositories when a formerly green MaikaTracker commit begins failing.
+
+## 6. Change checklists
+
+### Flag behavior
+
+- Read [Flag versioning](flag-versioning.md).
+- Search all `flagsetContains*` and `newFlagset()` call sites.
+- Test legacy, new, and null/no-flags modes.
+- Test readable, binary, URL/seed, reset, and JSON-load paths.
+- Verify shops, key-item defaults, logic, party rules, and XP behavior.
+
+### SNI behavior
+
+- Read [SNI autotracking](sni-autotracking.md).
+- Confirm A-bus/raw/FxPakPro semantics and ROM-side data ownership.
+- Update mappings and the documented address tables together.
+- Add decoder and transport tests.
+- Verify all-zero, unknown-bit, disconnect, and disabled-while-polling behavior.
+- Keep UI changes on the Swing EDT.
+
+### Persistence/imports
+
+- Read [State and data](state-and-data.md).
+- Preserve or migrate enum names, chest IDs, shop names, and checkbox names.
+- Round-trip an old and a newly saved JSON file.
+- Import a representative spoiler log.
+- Verify reset defaults before and after restore.
+
+### Swing/UI
+
+- Preserve NetBeans GUI Builder compatibility.
+- Avoid manual edits in generated blocks when possible.
+- Verify icon state cycling, checked-icon preference behavior, reset, and colors.
+- Launch the runnable JAR and inspect all affected tabs.
+
+## 7. Documentation maintenance
+
+Documentation should be changed in the same pull request when any of these change:
+
+- monitored SNI addresses, lengths, mappings, address modes, or configuration;
+- flag-family classification, aliases, or null semantics;
+- JSON fields or persisted identifiers;
+- project layers, dependencies, build layout, or release flow.
+
+The SNI address tables are intentionally explicit. Treat a mismatch between them and `SniTrackerMappings`/`SniAutoTrackerService` as a defect.

--- a/docs/flag-versioning.md
+++ b/docs/flag-versioning.md
@@ -1,0 +1,181 @@
+# Flag versioning and compatibility
+
+## 1. Two unrelated version systems
+
+MaikaTracker contains two version concepts that must not be confused:
+
+| Version | Stored/derived where | Purpose |
+| --- | --- | --- |
+| **FF4FE flag specification version** | `FlagSet.getVersion()`, decoded by FF4StatsLib from readable or binary flags | Selects the valid flag vocabulary and the gameplay/UI compatibility behavior. |
+| **MaikaTracker JSON state version** | `TrackerState.version`, currently `"1.0"` | Intended to describe the save-file schema. It currently has no migration dispatcher or validation logic. |
+
+A JSON state version of `1.0` says nothing about whether the contained FF4FE flags are legacy `0.3.x` flags or newer flags.
+
+## 2. Ownership boundary
+
+Flag parsing is delegated to the sibling **FF4StatsLib** project. MaikaTracker imports `sg4e.ff4stats.fe.FlagSet`, stores one current instance in `MaikaTracker.flagset`, and queries it by exact flag name.
+
+The dependency is configured as `../FF4StatsLib`, not as a versioned artifact. Consequently, the exact versions and parsing rules supported by a build are determined by the sibling checkout used at build time. MaikaTracker's own source defines the compatibility policy after parsing, but not the binary flag codec itself.
+
+## 3. Applying flags
+
+The Apply Flags action follows this sequence:
+
+1. Trim the entire flags text area.
+2. Call `FlagSet.from(text)`.
+3. On success, store the returned `FlagSet` and normalize the text area to readable flags, optionally preceded by binary flags.
+4. On `IllegalArgumentException`, display the parser message and set `flagset` to `null`.
+5. Recompute shop visibility, accessible-location logic, and key-item count.
+
+With the FF4StatsLib implementation expected by this project, `FlagSet.from` accepts:
+
+- readable flag text;
+- a URL containing flags or a binary seed identifier;
+- binary flags, optionally with a seed suffix.
+
+Do not implement a second parser in MaikaTracker. Add or correct flag-spec parsing in FF4StatsLib, then keep MaikaTracker's version-specific behavior at its UI/policy boundary.
+
+## 4. The legacy/new classification
+
+MaikaTracker intentionally reduces all parsed flag versions to two behavior families:
+
+```java
+public boolean newFlagset() {
+    return flagset != null && !flagset.getVersion().startsWith("0");
+}
+```
+
+- A version string beginning with `0` is treated as **legacy**.
+- Any non-null version not beginning with `0` is treated as **new**.
+- A null/invalid/unapplied flagset is **not new**.
+
+This is a compatibility heuristic, not semantic-version comparison. It does not compare major/minor numbers and it has no explicit table of supported versions. A future non-`0` specification will automatically enter the new branch, even if it changes flag meanings.
+
+The clearest example is `ShopPanel.UpdateFlags()`:
+
+- the legacy branch is documented in code as flags `0.3.0` through `0.3.8` and queries names such as `Sc`, `Sx`, `Ps`, `S4`, `Ji`, `-nosirens`, and `-noapples`;
+- the new branch is documented as `4.0.0+` and queries names such as `Scabins`, `Sempty`, `Pshop`, `Svanilla`, `Sshuffle`, `Sstandard`, `Spro`, `Swild`, `Sno:j`, and `Sno:sirens`.
+
+## 5. Flag query helpers and their null semantics
+
+`MaikaTracker` centralizes exact-name queries in `flagsetContains`, `flagsetContainsAll`, and `flagsetContainsAny`. They have an unusual but deliberate null policy.
+
+### Default overloads
+
+When `flagset == null`, the default query overloads return **true**:
+
+- `flagsetContains("Kmain")` → true;
+- `flagsetContainsAny("K", "Kmain")` → true;
+- `flagsetContainsAll("K", "Pkey")` → true.
+
+This makes the no-flags mode permissive: the tracker generally shows possibilities instead of hiding content it cannot disprove. Note that even `containsAll` returns true without flags, regardless of how many arguments it receives.
+
+### `allowNullFlagset` overloads
+
+The boolean overloads add an outer guard:
+
+```text
+(allowNullFlagset || flagset != null) && normalQuery(...)
+```
+
+Therefore:
+
+| Call shape while `flagset == null` | Result |
+| --- | --- |
+| `flagsetContainsAny("A", "B")` | true |
+| `flagsetContainsAny(true, "A", "B")` | true |
+| `flagsetContainsAny(false, "A", "B")` | false |
+| corresponding `contains`/`containsAll` forms | same policy |
+
+The `false` form is used when a feature must only be enabled by an explicitly parsed flag, such as legacy `Sc`, `Sx`, `-nosirens`, and `-noapples` shop restrictions.
+
+### Exact matching
+
+Queries delegate to `FlagSet.contains` and use exact canonical names. There is no substring, alias, or case-insensitive matching in MaikaTracker. Compatibility aliases are expressed explicitly at call sites, for example:
+
+- old `K` or new `Kmain`;
+- old `Pk` or new `Pkey`;
+- old `Ps` or new `Pshop`;
+- old `Nk` or newer `Nkey`/`Knofree`;
+- old `Kq` or new `Ksummon`;
+- old `Km` or new `Kmoon`.
+
+## 6. Where flags affect behavior
+
+### Shops
+
+`ShopPanel.UpdateFlags()` is the largest version split. It controls the visibility of item-category checkboxes according to legacy shop modes or newer tier/category flags. Shop checkbox names encode both a legacy category and a new-family tier/category, separated by commas; each version branch reads its own part.
+
+### Key-item availability and default locations
+
+`KeyItemPanel` uses flags to determine whether a key item may be assigned to a vanilla location, chest, or shop. On reset it also assigns deterministic locations when key-item randomization is off. Examples include:
+
+- Package at Start;
+- Sand Ruby at Antlion;
+- Crystal at Kokkól for `V1`, at Objective for `Owin:crystal`, otherwise Zeromus;
+- Twin Harp at Mist for no-free-key-item variants, otherwise Toroia;
+- Pass availability/location according to legacy/new pass flags.
+
+### Accessible-location logic
+
+`MaikaTracker.updateLogic()` asks FF4StatsLib for generally accessible locations, then applies compatibility aliases and special gates. Summon and lunar locations use old/new aliases; Kokkól and Objective depend on win-condition flags; some locations depend on key-item/pass randomization modes.
+
+### Party selection
+
+`PartyLabel` supports both legacy character flags (`-start...`, `-no...`, `-only`, `-nodupes`) and newer names (`Cstart:...`, `Cno:...`, `Conly:...`, `Cnodupes`). `MaikaTracker.SetStartingMember()` likewise recognizes both starting-character vocabularies.
+
+### XP behavior
+
+The XP calculator uses specific legacy flags when present and otherwise treats a new-family flagset as enabling newer default XP behavior, except for explicit vanilla XP behavior. This is another place where the coarse `newFlagset()` classification has gameplay consequences.
+
+## 7. Binary flags, readable flags, and seeds
+
+The UI can display readable flags alone or binary and readable flags together. `FlagSet` remains the canonical in-memory representation.
+
+When saving JSON:
+
+1. `flagset.getBinary()` is split at the first `.`;
+2. the portion before the dot is stored as `binary_flags`;
+3. readable canonical/legacy-formatted output is stored as `text_flags`;
+4. if the `FlagSet` has a seed, the suffix after the first dot is stored separately as `seed`.
+
+When loading JSON, the input placed into the flags text area is selected in this precedence order:
+
+1. if both text and binary flags are null, use `--NULL--` so applying/resetting produces no valid flagset;
+2. if nonblank binary flags and seed exist, use `binary_flags + "." + seed`;
+3. otherwise, if nonblank binary flags exist, use binary flags;
+4. otherwise use readable text flags.
+
+The load action then clicks Reset, and Reset first invokes Apply Flags. Thus all normal parsing, flag-dependent reset defaults, shop updates, and logic rebuilding happen before saved component state is restored.
+
+## 8. JSON state versioning limitations
+
+`TrackerState.version` defaults to `1.0`, and Jackson ignores unknown properties. However:
+
+- the loader does not inspect `version`;
+- there are no migration functions;
+- missing collections or fields can still cause errors depending on the data;
+- many per-entry restore operations catch and ignore exceptions;
+- enum names, chest IDs, and shop names act as de facto schema identifiers.
+
+If the JSON format changes, add explicit version validation/migration rather than only changing the default string.
+
+## 9. Safe procedure for supporting a new FF4FE flag version
+
+1. **Pin and inspect FF4StatsLib.** Confirm that it parses the version and maps readable/binary flags correctly.
+2. **Decide the family deliberately.** Do not assume `!version.startsWith("0")` is sufficient if the new specification changes semantics.
+3. **Inventory all aliases.** Search for `flagsetContains`, `newFlagset`, and literal flag names in `MaikaTracker`, `KeyItemPanel`, `PartyLabel`, and `ShopPanel`.
+4. **Update version-sensitive policies.** Shops, party rules, key-item defaults, accessible locations, and XP rules are separate consumers.
+5. **Test no-flags mode.** Preserve the intentional permissive/null behavior unless changing it is an explicit product decision.
+6. **Test all representations.** Apply readable flags, binary flags, a seed URL, and a saved JSON state.
+7. **Test reset and load.** Both paths reapply flags and can reveal defaults that direct UI testing misses.
+8. **Document the new aliases/family.** Keep this file and the relevant code comments synchronized.
+
+## 10. Common pitfalls
+
+- Treating JSON `version: "1.0"` as the FF4FE flag version.
+- Replacing the old/new heuristic with lexical string comparison; version strings are external identifiers, not safe decimal values.
+- Calling a default flag helper when absence of flags should mean false. Use the `false` boolean overload in that case.
+- Adding only the new spelling of a flag and breaking legacy flagsets.
+- Assuming readable flags are what gets restored; binary flags take precedence in saved state.
+- Forgetting that an unpinned FF4StatsLib checkout determines parsing behavior at build time.

--- a/docs/sni-autotracking.md
+++ b/docs/sni-autotracking.md
@@ -1,0 +1,331 @@
+# SNI autotracking
+
+## 1. Scope and guarantees
+
+MaikaTracker's SNI layer is a **read-only polling integration**. Once per second while enabled, it reads four FF4FE-maintained memory ranges, converts their bitfields/records into MaikaTracker domain values, and applies a complete snapshot to the Swing UI.
+
+It currently tracks:
+
+- which key items have been found;
+- which found key items have been used;
+- which mapped key-item locations have been checked;
+- the mapped location at which each of the first 17 key-item slots was found.
+
+It does **not** currently track bosses, party composition, chest state, shops, flags, ROM identity, or the seed. It also does not write any value to the emulator/device.
+
+## 2. Layered design
+
+```text
+SNI gRPC server / connected device
+              |
+              v
+SniGrpcMemoryReader  -- transport, device selection, address spaces
+              |
+              v
+SniAutoTrackerService -- scheduling and four fixed reads
+              |
+              v
+SniTrackerDecoder     -- bit/record decoding through mappings
+              |
+              v
+SniTrackerSnapshot    -- immutable-by-interface domain snapshot
+              |
+              v
+MaikaTracker.applyAutoTrackerSnapshot -- EDT/UI/logic application
+```
+
+### Classes
+
+| Class | Responsibility |
+| --- | --- |
+| `SniMemoryReader` | Minimal `read(int snesAddress, int length)` abstraction; enables fake readers in tests. |
+| `SniGrpcMemoryReader` | SNI device discovery, address-mode choice, memory-mapping detection, gRPC request construction, exact-length validation, and channel shutdown. |
+| `SniAutoTrackerService` | Scheduled poll loop, enable flag, fixed memory ranges, decoder/consumer connection, and throttled warnings. |
+| `SniTrackerMappings` | Explicit ROM-side bit/index to MaikaTracker enum mapping. Unknown bits are intentionally absent. |
+| `SniTrackerDecoder` | Generic little-endian bitfield decoding and two-byte found-location record decoding. |
+| `SniTrackerSnapshot` | Carries found items, used items, checked locations, and found-item locations as unmodifiable collections. |
+
+## 3. Configuration
+
+| Environment variable | Default | Meaning |
+| --- | --- | --- |
+| `MAIKA_SNI_GRPC_TARGET` | `127.0.0.1:8191` | gRPC target. A plain `host:port` is passed to `ManagedChannelBuilder.forAddress`; resolver-style targets containing `:///` are passed to `forTarget`. |
+| `MAIKA_SNI_DEVICE_URI` | unset | Exact SNI device URI to select. If absent, the first device advertising `ReadMemory` is selected; if none advertises it, the first listed device is selected anyway. |
+| `MAIKA_SNI_ADDRESS_MODE` | `AUTO` | One of `AUTO`, `SNES_ABUS`, `RAW`, or `FXPAKPRO`, case-insensitive. Invalid values silently become `AUTO`. |
+
+The gRPC channel uses plaintext. There is no TLS, authentication, per-call deadline, retry policy, or keepalive configuration in MaikaTracker.
+
+The UI checkbox controls the service's volatile `enabled` flag and is persisted in Java Preferences. The scheduled task exists even while disabled, but returns without reading.
+
+## 4. SNI protocol used by MaikaTracker
+
+`src/main/proto/sni/sni.proto` is a local SNI protocol definition in package `com.github.alttpo.sni`. Gradle generates protobuf message classes and blocking gRPC stubs from it.
+
+Although the schema declares device control, memory, filesystem, info, and NWA services, MaikaTracker calls only these RPCs:
+
+1. **`Devices.ListDevices(DevicesRequest) -> DevicesResponse`**
+   - Called on the first read only, unless constructing a new reader.
+   - The request has no `kinds` filter.
+   - The chosen `DevicesResponse.Device` is cached permanently for the reader's lifetime.
+
+2. **`DeviceMemory.MappingDetect(DetectMemoryMappingRequest) -> DetectMemoryMappingResponse`**
+   - Called when an A-bus request needs a ROM memory mapping and no usable mapping is cached.
+   - The request supplies only the selected device URI.
+   - `Unknown` is rejected as an `IOException`.
+   - The resulting mapping is cached.
+
+3. **`DeviceMemory.SingleRead(SingleReadMemoryRequest) -> SingleReadMemoryResponse`**
+   - Called once for each monitored range, sequentially.
+   - The outer request contains the selected device URI.
+   - The inner `ReadMemoryRequest` contains request address, address space, optional memory mapping, and size.
+   - Only `response.response.data` is consumed; response address metadata is not validated.
+   - Returned data length must exactly equal requested length or the read fails.
+
+MaikaTracker does not use `MultiRead` or `StreamRead`. Consequently, one logical poll is four independent gRPC reads and is not an atomic memory snapshot. The game can modify memory between reads.
+
+### One poll on the wire
+
+After device/mapping resolution, the regular poll is conceptually:
+
+```text
+SingleRead(uri, address=$7E1500, size=3)   -> found key-item bytes
+SingleRead(uri, address=$7E1503, size=3)   -> used key-item bytes
+SingleRead(uri, address=$7E1510, size=16)  -> checked-location bytes
+SingleRead(uri, address=$707080, size=34)  -> found-location records
+```
+
+All four must succeed and decode before the consumer receives a snapshot. A failure in any read drops the entire poll.
+
+## 5. Device discovery and caching semantics
+
+Device selection occurs lazily on the first call to `read`:
+
+1. call `ListDevices`;
+2. fail if no devices exist;
+3. if `MAIKA_SNI_DEVICE_URI` is set, require an exact URI match or fail;
+4. otherwise select the first device whose capabilities include `ReadMemory`;
+5. if no device advertises `ReadMemory`, select the first device anyway.
+
+The selected device is cached. It is never re-listed or invalidated after disconnect, URI change, or read failure. Restarting MaikaTracker (or creating a new reader) is currently the recovery path for a stale cached device.
+
+The reader's `read` method is synchronized, so concurrent callers cannot interleave device resolution or reads through one reader. The current poll service has only one worker anyway.
+
+## 6. Address spaces and translation
+
+The integer passed to `SniMemoryReader.read` is always authored as a **SNES A-bus address**. `SniGrpcMemoryReader` decides how to express that address to the selected backend.
+
+### AUTO mode
+
+| SNI device `kind` | Chosen mode |
+| --- | --- |
+| exactly `retroarch` | `RAW` |
+| exactly `fxpakpro` | `FXPAKPRO` |
+| anything else | `SNES_ABUS` |
+
+Kind comparisons are case-sensitive exact comparisons.
+
+### SNES_ABUS mode
+
+The request sends the original 24-bit address with `AddressSpace.SnesABus` and the result of `MappingDetect`. This lets SNI translate CPU-visible addresses to the backend/device representation.
+
+### RAW mode
+
+The request sends the original numeric address unchanged with `AddressSpace.Raw` and no memory mapping. AUTO uses this for `retroarch`. MaikaTracker assumes that backend's raw addressing accepts the monitored numeric addresses as sent.
+
+### FXPAKPRO mode
+
+For work RAM addresses `$7E0000` through `$7FFFFF`, MaikaTracker converts to the FxPakPro address space:
+
+```text
+fxpakpro_address = $F50000 + (snes_address - $7E0000)
+```
+
+Examples:
+
+| SNES A-bus | FxPakPro request |
+| --- | --- |
+| `$7E1500` | `$F51500` |
+| `$7E1503` | `$F51503` |
+| `$7E1510` | `$F51510` |
+
+Addresses outside `$7E0000..$7FFFFF` cannot use this conversion. In particular, `$707080` is sent as `SnesABus` with a detected mapping even when the overall mode is FXPAKPRO.
+
+For a translated FXPAKPRO read only, if every returned byte is zero, MaikaTracker retries the same logical address as `SnesABus` and returns the fallback if it contains any nonzero byte. If both are all zero, the primary all-zero result is retained. This heuristic helps backends that expose WRAM differently, but it also means an all-zero value causes an extra read and can be ambiguous when zero is the correct state.
+
+### Why `$707080` is different
+
+`$7E....`/`$7F....` are SNES work-RAM banks. `$707080` is outside that range and is treated by this code as a mapping-dependent A-bus address. The 34-byte data there behaves like persistent per-item location records. The project does not validate ROM/seed identity or document the ROM-side producer, so maintainers should describe it as the **FF4FE found-location table exposed at A-bus `$707080`**, not assume every ROM or mapping places generic SRAM there.
+
+## 7. Monitored memory layout
+
+All bitfields use **least-significant-bit first** indexing:
+
+```text
+global_bit_index = byte_index * 8 + bit_index
+bit_index 0 corresponds to mask $01
+bit_index 7 corresponds to mask $80
+```
+
+Unknown/unmapped set bits are ignored.
+
+### Summary table
+
+| A-bus start | Length | Shape | Meaning |
+| --- | ---: | --- | --- |
+| `$7E1500` | 3 bytes | 24-bit little bitfield | Found key items. Only indices 0–17 are mapped. |
+| `$7E1503` | 3 bytes | 24-bit little bitfield | Used key items, in the same key-item order. Only indices 0–17 are mapped. |
+| `$7E1510` | 16 bytes | 128-bit little bitfield | Checked location/event indices. Only explicitly mapped indices are consumed. |
+| `$707080` | 34 bytes | 17 little-endian unsigned 16-bit records | For item slot `i`, the location/event index where that key item was found. |
+
+The ranges do not overlap: found occupies `$7E1500..$7E1502`, used occupies `$7E1503..$7E1505`, checked occupies `$7E1510..$7E151F`, and found-location records occupy `$707080..$7070A1`.
+
+## 8. Found and used key-item bit semantics
+
+The same mapping applies to `$7E1500` and `$7E1503`. A set bit means the corresponding condition is true in that field. Importantly, **bit 0 is Package, not Crystal**.
+
+| Global bit | Byte.bit | Key item |
+| ---: | --- | --- |
+| `0` | `0.0` | Package |
+| `1` | `0.1` | Sand Ruby |
+| `2` | `0.2` | Baron Key |
+| `3` | `0.3` | Twin Harp |
+| `4` | `0.4` | Earth Crystal |
+| `5` | `0.5` | Magma Key |
+| `6` | `0.6` | Tower Key |
+| `7` | `0.7` | Hook |
+| `8` | `1.0` | Luca Key |
+| `9` | `1.1` | Darkness Crystal |
+| `10` | `1.2` | Rat Tail |
+| `11` | `1.3` | Pan |
+| `12` | `1.4` | Adamant |
+| `13` | `1.5` | Legend Sword |
+| `14` | `1.6` | Spoon |
+| `15` | `1.7` | Pink Tail |
+| `16` | `2.0` | Pass |
+| `17` | `2.1` | Crystal |
+| `18–23` | `2.2–2.7` | Unmapped/ignored |
+
+The decoder does not enforce `used ⊆ found`; it faithfully emits both sets. The UI only displays a used/check state for an item if `found` is also set, because snapshot application chooses state zero when not found.
+
+## 9. Checked-location bit semantics
+
+The 16-byte field at `$7E1510` can represent global indices `0x00..0x7F`, but MaikaTracker maps only selected FF4FE event/location indices. The first mapped index is `0x20`, so the first four bytes currently contain no consumed bits.
+
+| Global bit/index | Byte.bit | MaikaTracker location |
+| ---: | --- | --- |
+| `0x20` | `4.0` | START |
+| `0x21` | `4.1` | ANTLION |
+| `0x22` | `4.2` | FABUL |
+| `0x23` | `4.3` | ORDEALS |
+| `0x24` | `4.4` | BARON_INN |
+| `0x25` | `4.5` | BARON_CASTLE |
+| `0x26` | `4.6` | TOROIA |
+| `0x27` | `4.7` | DARK_ELF |
+| `0x28` | `5.0` | ZOT |
+| `0x29` | `5.1` | LOW_BABIL |
+| `0x2A` | `5.2` | TOP_BABIL |
+| `0x2B` | `5.3` | DWARF_CASTLE |
+| `0x2C` | `5.4` | SEALED_CAVE |
+| `0x2D` | `5.5` | SYLPH |
+| `0x2E` | `5.6` | RAT_TAIL |
+| `0x2F` | `5.7` | SHEILA_PANLESS |
+| `0x30` | `6.0` | SHEILA_PAN |
+| `0x31` | `6.1` | ASURA |
+| `0x32` | `6.2` | LEVIATAN *(enum spelling)* |
+| `0x33` | `6.3` | ODIN |
+| `0x34` | `6.4` | SUMMONED_MONSTERS_CHEST |
+| `0x35` | `6.5` | BAHAMUT |
+| `0x36` | `6.6` | PALE_DIM |
+| `0x37` | `6.7` | WYVERN |
+| `0x38` | `7.0` | PLAGUE |
+| `0x39` | `7.1` | DLUNAR |
+| `0x3A` | `7.2` | DLUNAR |
+| `0x3B` | `7.3` | OGOPOGO |
+| `0x59` | `11.1` | MIST |
+| `0x5A` | `11.2` | ZEROMUS |
+| `0x5D` | `11.5` | OBJECTIVE |
+
+Two different ROM-side indices (`0x39` and `0x3A`) deliberately collapse to the one `DLUNAR` enum. Because decoded results are sets, either or both set bits produce one visited location.
+
+When a snapshot is applied, `locationsVisited` is **cleared and replaced** by this mapped set. Manual visited-location entries not represented by a current mapped SNI bit are therefore removed on the next successful poll.
+
+## 10. Found-location record semantics
+
+The 34-byte range at `$707080` is decoded as 17 consecutive records:
+
+```text
+record i starts at offset i * 2
+location_index = low_byte | (high_byte << 8)
+item = KEY_ITEM_BY_BIT[i]
+location = LOCATION_BY_BIT[location_index]
+```
+
+Thus record order follows key-item indices `0..16`:
+
+```text
+Package, Sand Ruby, Baron Key, Twin Harp, Earth, Magma Key,
+Tower Key, Hook, Luca Key, Darkness, Rat Tail, Pan, Adamant,
+Legend, Spoon, Pink Tail, Pass
+```
+
+There is **no record for key-item index 17 (Crystal)** because 34 bytes hold only 17 two-byte records. Unknown location indices and absent item mappings are ignored. A record is included in `foundLocations` even if the corresponding found bit is not set, but the UI only applies a found location inside its `if (found)` branch.
+
+A location index uses the same numeric mapping table as checked-location bits; it is not a byte offset into the checked field. For example, bytes `20 00` decode to location index `0x0020`, which maps to `START`.
+
+## 11. Polling, decoding, and failure semantics
+
+`SniAutoTrackerService` creates a single-thread scheduled executor and schedules at a fixed rate. MaikaTracker supplies a 1000 ms initial delay and period.
+
+A poll:
+
+1. returns immediately if disabled;
+2. performs the four reads sequentially;
+3. decodes all values into sets/maps;
+4. invokes the snapshot consumer on the scheduler thread.
+
+Any exception from reading, decoding, or consuming aborts the poll. The service logs a warning at most once per five seconds, using only the exception message in the warning text. There is no user-visible connection status or backoff. Because calls have no deadlines, a stuck blocking RPC can also stall the sole scheduler thread.
+
+`close()` stops the scheduler immediately. `SniGrpcMemoryReader.close()` separately shuts down its gRPC channel with a one-second graceful timeout, but the current application service is typed against `SniMemoryReader` and does not itself close the reader. Maintainers adding lifecycle handling should close both resources.
+
+## 12. Snapshot application semantics
+
+`MaikaTracker.applyAutoTrackerSnapshot` immediately queues work on the Swing EDT. The queued action rechecks the UI checkbox, so a snapshot polled just before the user disables tracking is discarded.
+
+For every key-item panel:
+
+```text
+not found                         -> state 0
+found                             -> state 1
+found + used + checked-icons on   -> state 2
+found + used + checked-icons off  -> state 1
+```
+
+If an item is found and the snapshot has a mapped found location, `panel.setLocation(...)` is called. Existing locations are not explicitly cleared when a found-location record is absent, so stale/manual item locations can remain while the icon state is replaced.
+
+After key items, the application replaces `locationsVisited`, updates the key-item count, and rebuilds accessible-location logic. No flags are inferred or changed by SNI.
+
+## 13. Consistency limitations
+
+- Four `SingleRead` calls are not atomic; fields may reflect slightly different game moments.
+- A failed read discards the full poll, preserving the last UI state.
+- The selected device and mapping are cached indefinitely.
+- Unknown bits and indices are silently ignored.
+- All-zero FXPAKPRO reads trigger an A-bus fallback even when zero is valid.
+- There is no ROM hash, seed, or FF4FE version check before interpreting addresses.
+- Autotracking is authoritative for item icon states and mapped visited locations on every successful poll, but only opportunistically updates item-location labels.
+- The snapshot wraps the supplied mutable collections with unmodifiable views rather than defensive copies. The current decoder does not mutate them after construction, but future producers must not do so.
+
+## 14. Testing and extension checklist
+
+When adding an address, bit, or backend behavior:
+
+1. Confirm the ROM-side semantic and address space; distinguish A-bus, raw, and FxPakPro addresses.
+2. Add an explicit mapping rather than relying on enum ordinal values.
+3. Document byte order, bit order, length, and unmapped behavior.
+4. Add decoder tests for the first/last mapped bits, unknown bits, and duplicate/collapsed mappings.
+5. Add reader tests for request address space, mapping, exact length, and fallback behavior. The current suite does not cover `SniGrpcMemoryReader`.
+6. Consider whether the new data should replace manual state or only enrich it.
+7. Keep Swing mutation on the EDT.
+8. If consistency matters across fields, prefer one `MultiRead` request or add a consistency/version marker on the ROM side.
+9. Add device reconnect/cache invalidation if supporting long-running disconnect/reconnect cycles.
+10. Update this address table in the same change.

--- a/docs/state-and-data.md
+++ b/docs/state-and-data.md
@@ -1,0 +1,121 @@
+# State, imports, resources, and identifiers
+
+## 1. Where state lives
+
+MaikaTracker does not maintain one canonical run-state object during normal use. Current state is distributed across:
+
+- `StativeLabel` icon indices in key-item, boss, and party widgets;
+- key-item location/chest/shop references in `KeyItemPanel`;
+- `MaikaTracker.locationsVisited`;
+- chest labels inside `TreasureAtlas`;
+- shop checkboxes in static `ShopPanel` collections;
+- the current FF4StatsLib `FlagSet`;
+- Swing controls and Java Preferences.
+
+`TrackerState` is a serialization DTO assembled from those live objects only when saving.
+
+## 2. JSON save format
+
+`TrackerState` uses Jackson public fields and ignores unknown JSON properties. Default-valued booleans and null optional fields are omitted.
+
+Top-level fields:
+
+| Field | Meaning |
+| --- | --- |
+| `version` | Tracker JSON schema marker, currently `1.0`; not currently validated during load. |
+| `text_flags` | Readable FF4FE flags from the current `FlagSet`. |
+| `binary_flags` | Binary FF4FE flags without the dot-separated seed suffix. |
+| `seed` | Seed suffix when present. |
+| `keyItems` | Item enum name, location identifier, collected state, and used state. |
+| `locationsVisited` | `KeyItemLocation.name()` values. |
+| `bosses` | Boss identifier, slot/location identifier, seen state, and defeated state. |
+| `characters` | Five `LevelData.name()` values or null entries. |
+| `openedChests` | Stable treasure-atlas chest IDs. |
+| `shopItems` | Shop name to checked-item-name lists. |
+
+Key-item location strings are polymorphic identifiers: they may be a `KeyItemLocation.name()` or a chest ID. Shop location is intentionally not serialized in each key item because checked shop data handles it separately.
+
+Saving uses a pretty-printing Jackson writer and stores the last save directory in Preferences.
+
+## 3. JSON load sequence
+
+Load order matters because later operations assume flags/defaults are already applied:
+
+1. Deserialize JSON into `TrackerState`.
+2. Choose flag input using binary+seed, then binary, then readable text precedence.
+3. Click Reset, which first applies those flags and then resets all live state/defaults.
+4. Restore key-item state and location strings.
+5. Restore visited locations and progression side effects.
+6. Rebuild logic.
+7. Restore bosses and boss slots.
+8. Restore five party entries.
+9. Mark known chest IDs as opened.
+10. Restore checked shop items.
+
+Many individual restore blocks catch and ignore all exceptions. This provides partial forward/backward tolerance but can silently drop renamed/invalid identifiers. Top-level JSON read errors are logged and abort the load.
+
+## 4. Identifier stability
+
+The effective save schema depends on source-level identifiers:
+
+- `KeyItemMetadata` enum names;
+- FF4StatsLib `KeyItemLocation` enum names;
+- `BossLabel` identifiers accepted by `valueOf`;
+- FF4StatsLib `LevelData` enum names;
+- treasure chest IDs such as `Z1` or `E6`;
+- shop panel names and checkbox names.
+
+Renaming any of these can break old saves or spoiler imports even if the Java types still compile. Add migration aliases when renaming persisted identifiers.
+
+## 5. Spoiler-log importer
+
+The spoiler importer accepts `.txt` files and expects the first line to be exactly the FF4FE spoiler-log title. It then scans for named sections and parses their content directly into live UI state:
+
+- **Key Item Slots**: fixed-column location and item names; assigns key items to locations.
+- **Characters**: fixed-column location and character; populates party/start information.
+- **Battles**: fixed-column location and formation; maps spoiler formation names to boss labels.
+- **Treasures**: section/map headings plus regular expressions for item and battle chests; updates maps and contents.
+- **Shops**: shop headings and item patterns; updates shop checkboxes.
+
+The parser is intentionally tailored to a specific text layout. Heading, column-width, or phrasing changes in FF4FE spoiler logs can break it. When changing it, test a representative spoiler log containing key items, characters, bosses, battle chests, ordinary chests, and shops.
+
+## 6. Java Preferences versus run state
+
+Preferences are machine/user settings and are not part of a JSON run save. They include:
+
+- checked boss/key-item display behavior;
+- checked-overlay darkness;
+- reset-only behavior;
+- autotracking enabled state;
+- save and spoiler-log directories;
+- configured colors.
+
+This distinction matters when reproducing behavior: loading the same JSON on two machines can render differently or display used/defeated states differently because preferences control whether state `2` icons are used.
+
+## 7. Resources
+
+Runtime resources are loaded from the classpath through `MaikaTracker.loadResource` and `loadImageResource`.
+
+| Directory | Use |
+| --- | --- |
+| `src/main/resources/key-items/color` and `grayscale` | Key-item states. |
+| `src/main/resources/bosses/color` and `grayscale` | Boss states. |
+| `src/main/resources/bosses/checkmark.png` | Checked/defeated overlay compositing. |
+| `src/main/resources/characters` | Party sprites and unknown placeholder. |
+| `src/main/resources/maps/**` | Dungeon-floor maps and other map assets. |
+
+Resource filenames are referenced by code-generated strings and constants. Renaming an image can therefore compile successfully but fail at runtime. Keep color/grayscale pairs and expected naming patterns synchronized.
+
+Some resources are third-party assets with licensing terms described in the root README. Do not assume the source-code license permits arbitrary redistribution of every image.
+
+## 8. NetBeans form files
+
+`MaikaTracker.form`, `LocationPanel.form`, and `ShopPanel.form` are GUI Builder source files. Corresponding Java methods contain marked generated regions. The root README requires changes to generated GUI code to remain compatible with NetBeans GUI Builder.
+
+Recommended UI workflow:
+
+1. edit layouts/components through NetBeans GUI Builder where practical;
+2. keep custom logic outside generated regions;
+3. review both `.form` and `.java` diffs;
+4. build and manually launch the application;
+5. verify saved identifier/component names if shops or event handlers changed.


### PR DESCRIPTION
### Motivation

- Provide a single, discoverable developer documentation set so maintainers can reason about the large, stateful Swing app and the project boundaries without reverse-engineering generated forms. 
- Make the flag/version compatibility rules explicit so UI behavior (shops, key-item defaults, logic, XP) is predictable across legacy/new FF4FE flag families. 
- Thoroughly document the SNI autotracking integration and the exact ROM-memory semantics the app depends on to reduce risk when changing addresses, mappings, or transport behavior.

### Description

- Add a `docs/` index and detailed pages (`architecture.md`, `flag-versioning.md`, `sni-autotracking.md`, `state-and-data.md`, `development.md`) that describe architecture, data flow, persistence, resources, and maintenance checklists. 
- Document the flag-versioning model and query semantics including the two-version distinction (`FlagSet` vs `TrackerState`), the legacy/new heuristic (`newFlagset()`), exact-name queries, `allowNullFlagset` semantics, binary/readable precedence and common pitfalls. 
- Document the SNI pipeline and protocol in detail including environment configuration, device discovery behavior, address-space translation (`RAW`, `SNES_ABUS`, `FXPAKPRO`), the four polled ranges, bit/record decoding semantics, and limitations/extension checklist. 
- Update `README.md` with a developer-docs link and include guidance on build/test/CI expectations and the FF4StatsLib boundary.

### Testing

- Ran `./gradlew test` (including sibling `FF4StatsLib` build); the build and test task completed successfully. 
- Verified all relative Markdown links in the new docs resolve using a local validation script, and ran `git diff --cached --check` to ensure no whitespace/link warnings. 
- Cross-checked SNI constants and mapping tables (`FOUND_ADDR`, `USED_ADDR`, `CHECKED_ADDR`, `FOUND_LOCATION_ADDR`, `SniTrackerMappings`) against the documentation to ensure the documented addresses, sizes, and mapped indices match the code. 
- Confirmed the working tree reflects the doc additions and the docs are available from the repository root via the `README.md` link.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23e2e4c3d0832daf3e7b5e1500594b)